### PR TITLE
STI Support and validates_associated

### DIFF
--- a/lib/validation_scopes.rb
+++ b/lib/validation_scopes.rb
@@ -6,6 +6,19 @@ module ValidationScopes
     base.extend ClassMethods
   end
 
+  # Based on AssociatedValidator from ActiveRecord, see:
+  # activerecord-4.2.0/lib/active_record/validations/associated.rb @ line 3
+  class AssociatedValidator < ActiveModel::EachValidator
+    def validate_each(record, attribute, value)
+      all_valid = Array.wrap(value).all? do |r|
+        r.marked_for_destruction? || r.send("no_#{options[:scope]}?")
+      end
+      unless all_valid
+        record.errors.add(attribute, :invalid, options.merge(:value => value))
+      end
+    end
+  end
+
   module ClassMethods
     def validation_scope(scope)
       @all_scopes ||= []
@@ -19,6 +32,12 @@ module ValidationScopes
 
       proxy_class = Class.new(DelegateClass(base_class)) do
         include ActiveModel::Validations
+
+        @scope = scope
+        def self.validates_associated(*attr_names)
+          validates_with AssociatedValidator,
+            _merge_attributes(attr_names).merge(scope: @scope)
+        end
 
         def initialize(record)
           @base_record = record

--- a/lib/validation_scopes.rb
+++ b/lib/validation_scopes.rb
@@ -33,11 +33,7 @@ module ValidationScopes
 
       base_class = self
 
-      superclass = if self.superclass.validation_proxies[scope]
-                     self.superclass.validation_proxies[scope]
-                   else
-                     DelegateClass(base_class)
-                   end
+      superclass = self.superclass.validation_proxies[scope] || DelegateClass(base_class)
       proxy_class = Class.new(superclass) do
         include ActiveModel::Validations
 

--- a/lib/validation_scopes.rb
+++ b/lib/validation_scopes.rb
@@ -40,7 +40,7 @@ module ValidationScopes
         @scope = scope
         def self.validates_associated(*attr_names)
           validates_with AssociatedValidator,
-            _merge_attributes(attr_names).merge(scope: @scope)
+            _merge_attributes(attr_names).reverse_merge(scope: @scope)
         end
 
         def initialize(record)

--- a/lib/validation_scopes.rb
+++ b/lib/validation_scopes.rb
@@ -57,7 +57,7 @@ module ValidationScopes
           # Before Rails 4.1 callback functions were created using the class
           # name, so we must name our anonymous classes.
           define_method(:name) do
-            "#{base_class.name}ValidationProxy"
+            "#{base_class.name}#{scope.to_s.classify}ValidationProxy"
           end
         end
       end

--- a/test/db/schema.rb
+++ b/test/db/schema.rb
@@ -5,6 +5,7 @@ ActiveRecord::Schema.define do
     t.column "age",        :integer
     t.column "bio",        :text
     t.column "sponsor_id", :integer
+    t.column "type",       :string
   end
 
   create_table "books" do |t|

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -11,3 +11,10 @@ sponsored:
   age: 3
   bio: Alter-ego extraordinaire
   sponsor_id: 1
+important:
+  id: 3
+  name: Jeremy Mickelson
+  email: jeremy@mickelson.com
+  age: 27
+  bio: Super Hacker
+  type: ImportantUser

--- a/test/models/book.rb
+++ b/test/models/book.rb
@@ -10,4 +10,8 @@ class Book < ActiveRecord::Base
   validation_scope :alerts_book do |s|
     s.validates_presence_of :isbn
   end
+
+  validation_scope :alerts do |s|
+    s.validates_presence_of :isbn
+  end
 end

--- a/test/models/user.rb
+++ b/test/models/user.rb
@@ -18,6 +18,7 @@ class User < ActiveRecord::Base
 
   validation_scope :alerts do |s|
     s.validate :age_under_100
+    s.validates_associated :books
     s.validate { |r| r.alerts.add(:email, "We have a hotmail user.") if r.email =~ %r{@hotmail\.com\Z} }
   end
 

--- a/test/models/user.rb
+++ b/test/models/user.rb
@@ -8,6 +8,7 @@ class User < ActiveRecord::Base
     s.validates_presence_of  :email
     s.validates_format_of    :email, :with => %r{\A.+@.+\Z}
     s.validates_inclusion_of :age, :in => 0..99
+    s.validates_associated   :books, scope: :warnings_book
     s.validate do |r|
       if r.sponsor_id.present? && r.sponsor.nil?
         r.warnings.add(:sponsor_id, "Sponsor ID was defined but record not present")

--- a/test/models/user.rb
+++ b/test/models/user.rb
@@ -26,3 +26,9 @@ class User < ActiveRecord::Base
     alerts.add(:base, "We have a centenarian on our hands") if age && age >= 100
   end
 end
+
+class ImportantUser < User
+  validation_scope :warnings do |s|
+    s.validates_presence_of :bio
+  end
+end

--- a/test/test_validation_scopes.rb
+++ b/test/test_validation_scopes.rb
@@ -73,7 +73,7 @@ class TestValidationScopes < TestCase
 
   def test_validation_scopes
     assert_equal [:warnings, :alerts], User.validation_scopes
-    assert_equal [:warnings_book, :alerts_book], Book.validation_scopes
+    assert_equal [:warnings_book, :alerts_book, :alerts], Book.validation_scopes
   end
 
   def test_validates_associated
@@ -82,5 +82,13 @@ class TestValidationScopes < TestCase
     @user.books.first.author = nil
     assert @user.books.first.has_warnings_book?
     assert @user.has_warnings?
+  end
+
+  def test_validates_associated_default_scope
+    assert !@user.has_alerts?
+    assert @user.books.none? { |b| b.has_alerts? }
+    @user.books.first.isbn = nil
+    assert @user.books.first.has_alerts?
+    assert @user.has_alerts?
   end
 end

--- a/test/test_validation_scopes.rb
+++ b/test/test_validation_scopes.rb
@@ -91,4 +91,18 @@ class TestValidationScopes < TestCase
     assert @user.books.first.has_alerts?
     assert @user.has_alerts?
   end
+
+  def test_sti_inheritance_of_scopes
+    user = User.find(3)
+    assert_instance_of ImportantUser, user
+    assert user.no_warnings?
+    # Make sure super class validations work
+    user.email = nil
+    assert user.has_warnings?
+    user.email = 'a@b.com'
+    assert user.no_warnings?
+    # Make sure child class validations work
+    user.bio = nil
+    assert user.has_warnings?
+  end
 end

--- a/test/test_validation_scopes.rb
+++ b/test/test_validation_scopes.rb
@@ -75,4 +75,12 @@ class TestValidationScopes < TestCase
     assert_equal [:warnings, :alerts], User.validation_scopes
     assert_equal [:warnings_book, :alerts_book], Book.validation_scopes
   end
+
+  def test_validates_associated
+    assert !@user.has_warnings?
+    assert @user.books.none? { |b| b.has_warnings_book? }
+    @user.books.first.author = nil
+    assert @user.books.first.has_warnings_book?
+    assert @user.has_warnings?
+  end
 end

--- a/test/test_validation_scopes.rb
+++ b/test/test_validation_scopes.rb
@@ -71,8 +71,8 @@ class TestValidationScopes < TestCase
                  @user.validation_scope_proxy_for_warnings.class.model_name
   end
 
-  def test_all_scopes
-    assert_equal [:warnings, :alerts], User.all_scopes
-    assert_equal [:warnings_book, :alerts_book], Book.all_scopes
+  def test_validation_scopes
+    assert_equal [:warnings, :alerts], User.validation_scopes
+    assert_equal [:warnings_book, :alerts_book], Book.validation_scopes
   end
 end


### PR DESCRIPTION
This adds two new features: support for STI classes and `validates_associated`.

With the STI support, you can now have a parent class with a validation scope and a child class which adds to the same validation scope.  (With the current gem, the `validation_scope` in the child would overwrite the parent).

The built in Rails `validates_associated` method automatically checks the `valid?` method, so I added one that check the current scope's `no_#{scope}?` method. 

This branch also contains a few patches from other people to maintain compatibility with modern Rails (4+).  If you would like me to split these features out into a completely separate pull request, I would be happy to do so.  