### PR TITLE
Test against all versions of Rails 5 and Ruby

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,44 @@
 language: ruby
 rvm:
+  - 2.6
+  - 2.5
+  - 2.4
+  - 2.3
   - 2.2
   - 2.1
 cache: bundler
-before_install: gem install bundler
+before_install: gem install bundler -v 1.16.2
 gemfile:
   - gemfiles/rails_3.2.gemfile
   - gemfiles/rails_4.0.gemfile
   - gemfiles/rails_4.1.gemfile
   - gemfiles/rails_4.2.gemfile
   - gemfiles/rails_5.0.gemfile
+  - gemfiles/rails_5.1.gemfile
+  - gemfiles/rails_5.2.gemfile
 matrix:
   exclude:
   - rvm: 2.1
     gemfile: gemfiles/rails_5.0.gemfile
+  - rvm: 2.1
+    gemfile: gemfiles/rails_5.1.gemfile
+  - rvm: 2.1
+    gemfile: gemfiles/rails_5.2.gemfile
+  - rvm: 2.4
+    gemfile: gemfiles/rails_3.2.gemfile
+  - rvm: 2.4
+    gemfile: gemfiles/rails_4.0.gemfile
+  - rvm: 2.4
+    gemfile: gemfiles/rails_4.1.gemfile
+  - rvm: 2.5
+    gemfile: gemfiles/rails_3.2.gemfile
+  - rvm: 2.5
+    gemfile: gemfiles/rails_4.0.gemfile
+  - rvm: 2.5
+    gemfile: gemfiles/rails_4.1.gemfile
+  - rvm: 2.6
+    gemfile: gemfiles/rails_3.2.gemfile
+  - rvm: 2.6
+    gemfile: gemfiles/rails_4.0.gemfile
+  - rvm: 2.6
+    gemfile: gemfiles/rails_4.1.gemfile

--- a/Appraisals
+++ b/Appraisals
@@ -1,15 +1,35 @@
 appraise "rails-3.2" do
+  gem "sqlite3", "~> 1.3.6"
   gem "activerecord", "~> 3.2.22"
+  gem "minitest"
 end
 
 appraise "rails-4.0" do
+  gem 'sqlite3', '~> 1.3.6'
   gem "activerecord", "~> 4.0.13"
 end
 
 appraise "rails-4.1" do
+  gem 'sqlite3', '~> 1.3.6'
   gem "activerecord", "~> 4.1.11"
 end
 
 appraise "rails-4.2" do
+  gem 'sqlite3', '~> 1.3.6'
   gem "activerecord", "~> 4.2.2"
+end
+
+appraise "rails-5.0" do
+  gem 'sqlite3', '~> 1.3.6'
+  gem "activerecord", "~> 5.0.0"
+end
+
+appraise "rails-5.1" do
+  gem 'sqlite3', '~> 1.3.6'
+  gem "activerecord", "~> 5.1.0"
+end
+
+appraise "rails-5.2" do
+  gem 'sqlite3', '~> 1.3.6'
+  gem "activerecord", "~> 5.2.0"
 end

--- a/gemfiles/rails_4.0.gemfile
+++ b/gemfiles/rails_4.0.gemfile
@@ -3,6 +3,7 @@
 source "http://www.rubygems.org"
 
 gem "appraisal"
+gem "sqlite3", "~> 1.3.6"
 gem "activerecord", "~> 4.0.13"
 
 gemspec :path => "../"

--- a/gemfiles/rails_4.1.gemfile
+++ b/gemfiles/rails_4.1.gemfile
@@ -3,6 +3,7 @@
 source "http://www.rubygems.org"
 
 gem "appraisal"
+gem "sqlite3", "~> 1.3.6"
 gem "activerecord", "~> 4.1.11"
 
 gemspec :path => "../"

--- a/gemfiles/rails_4.2.gemfile
+++ b/gemfiles/rails_4.2.gemfile
@@ -3,6 +3,7 @@
 source "http://www.rubygems.org"
 
 gem "appraisal"
+gem "sqlite3", "~> 1.3.6"
 gem "activerecord", "~> 4.2.2"
 
 gemspec :path => "../"

--- a/gemfiles/rails_5.0.gemfile
+++ b/gemfiles/rails_5.0.gemfile
@@ -3,6 +3,7 @@
 source "http://www.rubygems.org"
 
 gem "appraisal"
+gem "sqlite3", "~> 1.3.6"
 gem "activerecord", "~> 5.0.0"
 
 gemspec :path => "../"

--- a/gemfiles/rails_5.1.gemfile
+++ b/gemfiles/rails_5.1.gemfile
@@ -4,7 +4,6 @@ source "http://www.rubygems.org"
 
 gem "appraisal"
 gem "sqlite3", "~> 1.3.6"
-gem "activerecord", "~> 3.2.22"
-gem "minitest"
+gem "activerecord", "~> 5.1.0"
 
 gemspec :path => "../"

--- a/gemfiles/rails_5.2.gemfile
+++ b/gemfiles/rails_5.2.gemfile
@@ -4,7 +4,6 @@ source "http://www.rubygems.org"
 
 gem "appraisal"
 gem "sqlite3", "~> 1.3.6"
-gem "activerecord", "~> 3.2.22"
-gem "minitest"
+gem "activerecord", "~> 5.2.0"
 
 gemspec :path => "../"


### PR DESCRIPTION
In order to ensure we have the right version of sqlite3 (since a specific version is required by these versions of active record), we define it explicitly in the appraisals file. We can also use this to add minitest for the Rails 3.2 build automatically.